### PR TITLE
Launch Shiny apps on random port by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file. -->
 
-## [Unreleased]
+## 0.0.4
+
+- The default value for `shiny.python.port` is now `0`, which means "choose an unused port at runtime". This is convenient for running multiple apps simultaneously on the same machine. For convenience, the extension remembers each VS Code Workspace's most recent random port, and tries to use it if available.
+
+## 0.0.3
 
 - Initial release

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "pyshiny",
   "displayName": "Shiny for Python",
   "description": "Shiny for Python support",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "publisher": "rstudio",
   "icon": "logo.png",
   "repository": {
@@ -50,8 +50,8 @@
       "properties": {
         "shiny.python.port": {
           "type": "integer",
-          "default": 8000,
-          "description": "The port number to listen on when running an app."
+          "default": 0,
+          "description": "The port number to listen on when running an app. (Use 0 to choose a random port for each workspace.)"
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,9 @@ export const TERMINAL_NAME = "Shiny";
 
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
-    vscode.commands.registerCommand("shiny.python.runApp", runApp)
+    vscode.commands.registerCommand("shiny.python.runApp", () =>
+      runApp(context)
+    )
   );
 
   const throttledUpdateContext = new Throttler(2000, updateContext);

--- a/src/run.ts
+++ b/src/run.ts
@@ -2,10 +2,13 @@ import * as vscode from "vscode";
 import * as http from "http";
 import { retryUntilTimeout } from "./retry-utils";
 import { TERMINAL_NAME, PYSHINY_EXEC_CMD } from "./extension";
+import { AddressInfo } from "net";
+import { resolve } from "path";
 
-export async function runApp() {
+export async function runApp(context: vscode.ExtensionContext) {
   const port: number =
-    vscode.workspace.getConfiguration("shiny.python").get("port") ?? 8000;
+    vscode.workspace.getConfiguration("shiny.python").get("port") ||
+    (await defaultPort(context));
 
   // Gather details of the current Python interpreter. We want to make sure
   // only to re-use a terminal if it's using the same interpreter.
@@ -79,7 +82,7 @@ export async function runApp() {
   }
 
   try {
-    await retryUntilTimeout(10000, () => isPortOpen("localhost", port));
+    await retryUntilTimeout(10000, () => isPortOpen("127.0.0.1", port));
   } catch {
     // Failed to connect. Don't bother trying to launch a browser
     console.warn("Failed to connect to Shiny app, not launching browser");
@@ -88,10 +91,80 @@ export async function runApp() {
 
   vscode.commands.executeCommand(
     "simpleBrowser.api.open",
-    `http://localhost:${port}`,
+    `http://127.0.0.1:${port}`,
     {
       preserveFocus: true,
       viewColumn: vscode.ViewColumn.Beside,
     }
   );
+}
+
+const UNSAFE_PORTS = [
+  1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42, 43, 53, 77, 79, 87,
+  95, 101, 102, 103, 104, 109, 110, 111, 113, 115, 117, 119, 123, 135, 139, 143,
+  179, 389, 427, 465, 512, 513, 514, 515, 526, 530, 531, 532, 540, 548, 556,
+  563, 587, 601, 636, 993, 995, 2049, 3659, 4045, 6000, 6665, 6666, 6667, 6668,
+  6669, 6697,
+];
+
+async function defaultPort(context: vscode.ExtensionContext): Promise<number> {
+  let port: number = context.workspaceState.get("transient_port", 0);
+  while (port === 0 || !(await verifyPort(port))) {
+    do {
+      port = await suggestPort();
+      // Ports that are considered unsafe by Chrome
+      // http://superuser.com/questions/188058/which-ports-are-considered-unsafe-on-chrome
+      // https://github.com/rstudio/shiny/issues/1784
+    } while (UNSAFE_PORTS.includes(port));
+    await context.workspaceState.update("transient_port", port);
+  }
+  return port;
+}
+
+async function suggestPort(): Promise<number> {
+  const server = http.createServer();
+
+  const p = new Promise<number>((resolve, reject) => {
+    server.on("listening", () =>
+      resolve((server.address() as AddressInfo).port)
+    );
+    server.on("error", reject);
+  }).finally(() => {
+    return closeServer(server);
+  });
+
+  server.listen(0, "127.0.0.1");
+
+  return p;
+}
+
+async function verifyPort(
+  port: number,
+  host: string = "127.0.0.1"
+): Promise<boolean> {
+  const server = http.createServer();
+
+  const p = new Promise<boolean>((resolve, reject) => {
+    server.on("listening", () => resolve(true));
+    server.on("error", () => resolve(false));
+  }).finally(() => {
+    return closeServer(server);
+  });
+
+  server.listen(port, host);
+
+  return p;
+}
+
+async function closeServer(server: http.Server): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    server.close((errClose) => {
+      if (errClose) {
+        // Don't bother logging, we don't care (e.g. if the server
+        // failed to listen, close() will fail)
+      }
+      // Whether close succeeded or not, we're now ready to continue
+      resolve();
+    });
+  });
 }

--- a/src/run.ts
+++ b/src/run.ts
@@ -111,6 +111,7 @@ const UNSAFE_PORTS = [
 ];
 
 async function defaultPort(context: vscode.ExtensionContext): Promise<number> {
+  // Retrieve most recently used port
   let port: number = context.workspaceState.get("transient_port", 0);
   while (port === 0 || !(await verifyPort(port))) {
     do {

--- a/src/run.ts
+++ b/src/run.ts
@@ -99,6 +99,9 @@ export async function runApp(context: vscode.ExtensionContext) {
   );
 }
 
+// Ports that are considered unsafe by Chrome
+// http://superuser.com/questions/188058/which-ports-are-considered-unsafe-on-chrome
+// https://github.com/rstudio/shiny/issues/1784
 const UNSAFE_PORTS = [
   1, 7, 9, 11, 13, 15, 17, 19, 20, 21, 22, 23, 25, 37, 42, 43, 53, 77, 79, 87,
   95, 101, 102, 103, 104, 109, 110, 111, 113, 115, 117, 119, 123, 135, 139, 143,


### PR DESCRIPTION
But also try not to change ports unnecessarily (each workspace tries to reuse the previous random port, if available)