### PR TITLE
First attempt at Open VSX publish (dry run)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,8 +13,13 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: "18.x"
       - run: yarn install --immutable --immutable-cache --check-cache
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+          dryRun: ${{ github.ref_name == 'main' }}
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@v1
         with:


### PR DESCRIPTION
This PR adds a GHA workflow step to publish the extension to Open-VSX.org (in addition to the existing VS Code Marketplace publishing step).