### PR TITLE
Add "Debug Shiny App" command to editor run menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 <!-- Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file. -->
 
+## 0.1.3
+
+- Add "Debug Shiny App" button to launch Shiny apps under the Python debugger. (#17)
+
 ## 0.1.2
 
 - Recognize files named app-\*.py and app\_\*.py as potentially Shiny apps (and enabling the "Run Shiny App" button).

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "shiny-python",
   "displayName": "Shiny for Python",
   "description": "Shiny for Python support",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "publisher": "Posit",
   "icon": "logo.png",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -65,6 +65,11 @@
           "type": "integer",
           "default": 0,
           "description": "The port number to listen on when running an app. (Use 0 to choose a random port for each workspace.)"
+        },
+        "shiny.python.debug.justMyCode": {
+          "type": "boolean",
+          "default": true,
+          "description": "When running the \"Debug Shiny App\" command, whether to skip over code in packages."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -66,10 +66,10 @@
           "default": 0,
           "description": "The port number to listen on when running an app. (Use 0 to choose a random port for each workspace.)"
         },
-        "shiny.python.debug.justMyCode": {
+        "shiny.python.debugJustMyCode": {
           "type": "boolean",
           "default": true,
-          "description": "When running the \"Debug Shiny App\" command, whether to skip over code in packages."
+          "description": "When running the \"Debug Shiny App\" command, only step through user-written code. Disable this to allow stepping through library code."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   ],
   "activationEvents": [
     "onLanguage:python",
-    "onCommand:shiny.python.runApp"
+    "onCommand:shiny.python.runApp",
+    "onCommand:shiny.python.debugApp"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -34,12 +35,24 @@
         "title": "Run Shiny App",
         "icon": "$(play)",
         "enablement": "editorLangId == python && shellExecutionSupported"
+      },
+      {
+        "category": "Shiny",
+        "command": "shiny.python.debugApp",
+        "title": "Debug Shiny App",
+        "icon": "$(debug-alt)",
+        "enablement": "editorLangId == python && shellExecutionSupported"
       }
     ],
     "menus": {
       "editor/title/run": [
         {
           "command": "shiny.python.runApp",
+          "group": "navigation@-3",
+          "when": "shiny.python.active && shellExecutionSupported"
+        },
+        {
+          "command": "shiny.python.debugApp",
           "group": "navigation@-2",
           "when": "shiny.python.active && shellExecutionSupported"
         }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,37 +7,6 @@ export const TERMINAL_NAME = "Shiny";
 
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
-    vscode.debug.registerDebugConfigurationProvider("shiny-python", {
-      provideDebugConfigurations: () => {
-        return [
-          {
-            name: "Shiny",
-            type: "shiny-python",
-            request: "launch",
-            program: "${file}",
-            console: "integratedTerminal",
-            env: {
-              PYSHINY_EXEC_CMD: "shiny",
-            },
-          },
-        ];
-      },
-      resolveDebugConfiguration(folder, debugConfiguration, token) {
-        debugConfiguration.type = "python";
-        debugConfiguration.request = "launch";
-        debugConfiguration.module = "shiny";
-        debugConfiguration.args = [
-          "run",
-          "--port",
-          "0",
-          debugConfiguration.program,
-        ];
-        return debugConfiguration;
-      },
-    })
-  );
-
-  context.subscriptions.push(
     vscode.commands.registerCommand("shiny.python.runApp", () =>
       runApp(context)
     ),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,14 +1,48 @@
 import * as vscode from "vscode";
 import * as path from "path";
-import { runApp } from "./run";
+import { runApp, debugApp } from "./run";
 
 export const PYSHINY_EXEC_CMD = "PYSHINY_EXEC_CMD";
 export const TERMINAL_NAME = "Shiny";
 
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
+    vscode.debug.registerDebugConfigurationProvider("shiny-python", {
+      provideDebugConfigurations: () => {
+        return [
+          {
+            name: "Shiny",
+            type: "shiny-python",
+            request: "launch",
+            program: "${file}",
+            console: "integratedTerminal",
+            env: {
+              PYSHINY_EXEC_CMD: "shiny",
+            },
+          },
+        ];
+      },
+      resolveDebugConfiguration(folder, debugConfiguration, token) {
+        debugConfiguration.type = "python";
+        debugConfiguration.request = "launch";
+        debugConfiguration.module = "shiny";
+        debugConfiguration.args = [
+          "run",
+          "--port",
+          "0",
+          debugConfiguration.program,
+        ];
+        return debugConfiguration;
+      },
+    })
+  );
+
+  context.subscriptions.push(
     vscode.commands.registerCommand("shiny.python.runApp", () =>
       runApp(context)
+    ),
+    vscode.commands.registerCommand("shiny.python.debugApp", () =>
+      debugApp(context)
     )
   );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 import * as path from "path";
-import { runApp, debugApp } from "./run";
+import { runApp, debugApp, onDidStartDebugSession } from "./run";
 
 export const PYSHINY_EXEC_CMD = "PYSHINY_EXEC_CMD";
 export const TERMINAL_NAME = "Shiny";
@@ -67,6 +67,8 @@ export function activate(context: vscode.ExtensionContext) {
     })
   );
   throttledUpdateContext.immediateCall();
+
+  vscode.debug.onDidStartDebugSession(onDidStartDebugSession);
 }
 
 // this method is called when your extension is deactivated

--- a/src/run.ts
+++ b/src/run.ts
@@ -72,7 +72,7 @@ export async function debugApp(context: vscode.ExtensionContext) {
 
     const justMyCode = vscode.workspace
       .getConfiguration("shiny.python")
-      .get("port", true);
+      .get("debugJustMyCode", true);
 
     await vscode.debug.startDebugging(undefined, {
       type: "python",

--- a/src/run.ts
+++ b/src/run.ts
@@ -62,9 +62,15 @@ export async function runApp(context: vscode.ExtensionContext) {
 
 export async function debugApp(context: vscode.ExtensionContext) {
   runAppImpl(context, async (path, port) => {
+    const DEBUG_NAME = "Debug Shiny app";
+
+    if (vscode.debug.activeDebugSession?.name === DEBUG_NAME) {
+      await vscode.debug.stopDebugging(vscode.debug.activeDebugSession);
+    }
+
     await vscode.debug.startDebugging(undefined, {
       type: "python",
-      name: "Debug Shiny app",
+      name: DEBUG_NAME,
       request: "launch",
       module: "shiny",
       args: ["run", "--port", port.toString(), path],

--- a/src/run.ts
+++ b/src/run.ts
@@ -70,6 +70,10 @@ export async function debugApp(context: vscode.ExtensionContext) {
       await vscode.debug.stopDebugging(vscode.debug.activeDebugSession);
     }
 
+    const justMyCode = vscode.workspace
+      .getConfiguration("shiny.python")
+      .get("port", true);
+
     await vscode.debug.startDebugging(undefined, {
       type: "python",
       name: DEBUG_NAME,
@@ -77,7 +81,7 @@ export async function debugApp(context: vscode.ExtensionContext) {
       module: "shiny",
       args: ["run", "--port", port.toString(), path],
       jinja: true,
-      justMyCode: true,
+      justMyCode,
       stopOnEntry: false,
     });
 


### PR DESCRIPTION
Anytime you see "Run Shiny App" on the editor run menu, you should now also see "Debug Shiny App" right below it. This will launch the Python debugger on the currently focused Shiny app file, using a random-ish port, and launch the Simple Browser when the app is ready.

## Open question

- There's an advanced debugger config flag `justMyCode` which I've hardcoded to `true`--this means that breakpoints in third party packages won't be respected. LMK if you disagree.

## Testing notes

(I have done these all BTW, just documenting the scenarios I thought worth testing)

- Set breakpoints in various places (top level, in server function, in `@reactive.XXX` and render functions) in app.py and Shiny modules and ensure the debugger actually stops on them.
- Invoking "Debug Shiny App", and then invoking it again without stopping the first debug session, should kill the first debug session and start a new one.
- Hitting "Restart" button in VS Code's floating debugging toolbar works, and the Simple Browser window opens or reloads
- "Debug Shiny App" only shows up on the intended files (files named `app.py` or `app-*.py`, with the string "shiny" in them I believe). Same as "Run Shiny App".